### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Sometimes it emulates fail with some abort:
 Python>from idaemu import *
 Python>a = Emu(UC_ARCH_ARM, UC_MODE_THUMB)
 Python>print a.eFunc(here(), 0xbeae, [4])
-#ERROR: Invalid instruction (UC_ERR_INSN_INVALID)
+# ERROR: Invalid instruction (UC_ERR_INSN_INVALID)
 1048576
 ```
 
@@ -128,7 +128,7 @@ Python>from idaemu import *
 Python>a = Emu(UC_ARCH_ARM, UC_MODE_THUMB)
 Python>a.setTrace(TRACE_CODE)
 Python>a.eFunc(here(), 0xbeae, [4])
-#ERROR: Invalid instruction (UC_ERR_INSN_INVALID)
+# ERROR: Invalid instruction (UC_ERR_INSN_INVALID)
 1048576
 Python>a.showTrace()
 ### Trace Instruction at 0x13dc, size = 2


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
